### PR TITLE
Multiple updates.

### DIFF
--- a/GSLT/src/main/bnfc/metta_venus.cf
+++ b/GSLT/src/main/bnfc/metta_venus.cf
@@ -199,22 +199,8 @@ Rule . Def ::= Label "." Cat "::=" [Item] ;
 -- Items
 Terminal         . Item ::= String ;
 NTerminal        . Item ::= Cat ;
-
--- BindTerminal Item
-BindTerminal . Item ::= "(" "Bind" Ident IntList ")" ;
--- Ident defines the category C of the variable; a new rule
---   IdC . C ::= Ident
--- Error if Ident is already the RHS of a rule for C.
--- IntList specifies where in the term the variable is bound.
---    Lam. T ::= "λ" (Bind T [1]) "." T                             -- bound in body
---    For. P ::= "for" "(" (Bind Name [2]) "<-" Ident ")" "{" P "}" -- not bound in channel name
--- Can bind the variable in subterms appearing before the binder.
---    Foo. P ::= "foo" P "bar" (Bind P [0, 3]) "baz" P ":" P        -- not bound in slot 2
--- Error if the list is empty, contains its own slot, or contains
---    a number greater than or equal to the number of slots.
--- Effectively adds Ident as RHS of new rule.
--- Parser generated from GSLT accepts Ident in this position.
-
+AbsNTerminal     . Item ::= "(" Ident ")" Cat;
+BindNTerminal    . Item ::= "(" "Bind" Ident Ident ")" ;
 
 -- Categories
 ListOfCat     . Cat ::= "[" Cat "]" ;

--- a/GSLT/src/main/bnfc/metta_venus.cf
+++ b/GSLT/src/main/bnfc/metta_venus.cf
@@ -210,18 +210,12 @@ ImportedCat . Cat ::= Ident "." Cat;
 [] . [Cat] ::= ;
 (:) . [Cat] ::= Cat ";" [Cat] ;
 
--- labels with or without profiles
-LabNoP   . Label ::= LabelId ;
-LabP     . Label ::= LabelId [ProfItem] ;
-LabPF    . Label ::= LabelId LabelId [ProfItem] ;
-LabF     . Label ::= LabelId LabelId ;
-
 -- functional labels
-Id       . LabelId ::= Ident ;
-Wild     . LabelId ::= "_" ;
-ListE    . LabelId ::= "[" "]" ;
-ListCons . LabelId ::= "(" ":" ")" ;
-ListOne  . LabelId ::= "(" ":" "[" "]" ")" ;
+Id       . Label ::= Ident ;
+Wild     . Label ::= "_" ;
+ListE    . Label ::= "[" "]" ;
+ListCons . Label ::= "(" ":" ")" ;
+ListOne  . Label ::= "(" ":" "[" "]" ")" ;
 
 -- profiles (= permutation and binding patterns)
 ProfIt   . ProfItem ::= "(" "[" [IntList] "]" "," "[" [Integer] "]" ")" ;
@@ -304,7 +298,7 @@ RewriteContext . Rewrite ::= "let" Hypothesis "in" Rewrite ;
 
 ASTSubst . AST ::= "(" "Subst" AST AST Ident ")";
 ASTVar   . AST ::= Ident ;
-ASTSExp  . AST ::= "(" Ident [AST] ")" ;
+ASTSExp  . AST ::= "(" Label [AST] ")" ;
 
 []  . [AST] ::= ;
 (:) . [AST] ::= AST [AST] ;

--- a/GSLT/src/test/module/Rholang.module
+++ b/GSLT/src/test/module/Rholang.module
@@ -67,6 +67,10 @@ Module Rholang {
   Theory Rholang(nr: NewReplCalc, r: RhoCalc) {
     nr \/ r
   }
+
+  Theory FreeMonoid() {
+    let m = u.Monoid() in (m)
+  }
   
   Theory FreeRholang() {
     let m = u.Monoid() in (
@@ -80,5 +84,7 @@ Module Rholang {
     )))))))
   }
 
-  theory FreeRholang()
+  theory let m = u.Monoid() in (
+    let cm = u.CommutativeMonoid(m) in (
+    let pm = ParMonoid(cm) in (pm)))
 }

--- a/GSLT/src/test/module/Rholang.module
+++ b/GSLT/src/test/module/Rholang.module
@@ -23,7 +23,7 @@ Module Rholang {
       }
       Terms {
         PRepl . Proc ::= "!" Proc ;
-        PNew  . Proc ::= "new" (Bind Name [1]) "in" Proc ;
+        PNew  . Proc ::= "new" (Bind Name x) "in" [x]Proc ;
       }
       Equations {
         if x # Q then
@@ -57,7 +57,7 @@ Module Rholang {
     qd
       Terms {
         PSend . Proc ::= Name "!" "(" Proc ")" ;
-        PRecv . Proc ::= "for" "(" (Bind Name [2]) "<-" Name ")" "{" Proc "}" ;
+        PRecv . Proc ::= "for" "(" (Bind Name x) "<-" Name ")" "{" [x]Proc "}" ;
       }
       Rewrites {
         RComm : ( PPar ( PRecv y x P) ( PSend x Q ) ) ~> ( Subst P ( NQuote Q ) y ) ;

--- a/MeTTaIL/src/main/scala/io/f1r3fly/mettail/InstInterpreter.scala
+++ b/MeTTaIL/src/main/scala/io/f1r3fly/mettail/InstInterpreter.scala
@@ -14,7 +14,7 @@ class InstInterpreter(resolvedModules: Map[String, Module], currentModulePath: S
     case disj: TheoryInstDisj           => handleDisj(this, env, disj)
     case conj: TheoryInstConj           => handleConj(this, env, conj)
     case addExports: TheoryInstAddExports => handleAddExports(this, env, addExports)
-    case addReplacements: TheoryInstAddReplacements => handleAddReplacements()
+    case addReplacements: TheoryInstAddReplacements => handleAddReplacements(this, env, addReplacements)
     case addTerms: TheoryInstAddTerms   => handleAddTerms(this, env, addTerms)
     case addEquations: TheoryInstAddEquations => handleAddEquations(this, env, addEquations)
     case addRewrites: TheoryInstAddRewrites => handleAddRewrites(this, env, addRewrites)
@@ -27,7 +27,7 @@ class InstInterpreter(resolvedModules: Map[String, Module], currentModulePath: S
 
   // Used in conj, rewrites, and equations
   private def labelsInAST(ast: AST): Set[String] = ast match {
-    case astSExp: ASTSExp => Set(astSExp.ident_)
+    case astSExp: ASTSExp => Set(labelToString(astSExp.label_))
     case _                => Set.empty[String]
   }
 

--- a/MeTTaIL/src/main/scala/io/f1r3fly/mettail/Main.scala
+++ b/MeTTaIL/src/main/scala/io/f1r3fly/mettail/Main.scala
@@ -51,12 +51,12 @@ object Main {
                 println(s"\nError during interpretation: $error")
             }
           case None =>
-            println("No TheoryInst found in the main module.")
+            println("No TheoryInst found in the main module of ${entryPath}}.")
         }
       case Some(_) =>
-        println("Main module is not a ModuleImpl.")
+        println("Main module ${entryPath}} is not a ModuleImpl.")
       case None =>
-        println("Main module not found in resolved modules.")
+        println("Main module ${entryPath}} not found in resolved modules.")
     }
   }
 }


### PR DESCRIPTION
- Update handleAddTerms, handleAddEquations, and handleAddRewrites to check that the categories and labels being referenced exist in the presentation. 
- Change binder syntax, fix build issue.
- Have handleAddRewrites check to see that variables appearing on the right-hand side of a rewrite also appear on the left.
- Get rid of profiles in labels, use labels in AST instead of idents. 
- Add handleAddReplacements function. 
- Add rewrite hypothesis variables to LHS. 
- Add some information to error messages to help find the error location.
