### PR TITLE
Mike

### DIFF
--- a/GSLT/src/main/bnfc/metta_venus.cf
+++ b/GSLT/src/main/bnfc/metta_venus.cf
@@ -213,9 +213,9 @@ ImportedCat . Cat ::= Ident "." Cat;
 -- functional labels
 Id       . Label ::= Ident ;
 Wild     . Label ::= "_" ;
-ListE    . Label ::= "[" "]" ;
-ListCons . Label ::= "(" ":" ")" ;
-ListOne  . Label ::= "(" ":" "[" "]" ")" ;
+ListE    . Label ::= "[" "]" "{" Cat "}";
+ListCons . Label ::= "(" ":" ")" "{" Cat "}";
+ListOne  . Label ::= "(" ":" "[" "]" ")" "{" Cat "}";
 
 -- profiles (= permutation and binding patterns)
 ProfIt   . ProfItem ::= "(" "[" [IntList] "]" "," "[" [Integer] "]" ")" ;

--- a/GSLT/src/main/bnfc/metta_venus.cf
+++ b/GSLT/src/main/bnfc/metta_venus.cf
@@ -199,7 +199,7 @@ Rule . Def ::= Label "." Cat "::=" [Item] ;
 -- Items
 Terminal         . Item ::= String ;
 NTerminal        . Item ::= Cat ;
-AbsNTerminal     . Item ::= "(" Ident ")" Cat;
+AbsNTerminal     . Item ::= "(" Ident ")" Item;
 BindNTerminal    . Item ::= "(" "Bind" Ident Cat ")" ;
 
 -- Categories

--- a/GSLT/src/main/bnfc/metta_venus.cf
+++ b/GSLT/src/main/bnfc/metta_venus.cf
@@ -71,7 +71,7 @@ TheoryInstDisj . TheoryInst3 ::= TheoryInst3 "\\/" TheoryInst4 ;
 TheoryInstSubtract . TheoryInst2 ::= TheoryInst2 "\\" TheoryInst3 ;
 separator TheoryInst "," ;
 
-BasePres . Pres ::= "Presentation" "Equations" "{" [Cat] "}" "Terms" "{" [Def] "}" "Equations" "{" [Equation] "}" "Rewrites" "{" [RewriteDecl] "}" ;
+BasePres . Pres ::= "Presentation" "Exports" "{" [Cat] "}" "Terms" "{" [Def] "}" "Equations" "{" [Equation] "}" "Rewrites" "{" [RewriteDecl] "}" ;
 
 BaseSpaceDecl . SpaceDecl ::= "Space" Name "(" [VariableDecl] ")" "{" [Fact] [FactComprehension] "}" ;
 BaseTheoryDecl . TheoryDecl ::= "Theory" Name "(" [VariableDecl] ")" "{" TheoryInst "}" ;

--- a/GSLT/src/test/module/List.module
+++ b/GSLT/src/test/module/List.module
@@ -1,0 +1,34 @@
+Module List {
+  Theory ListOfNat() {
+    Empty
+      Exports {
+        Digit;
+        [Digit];
+        Nat;
+        [Nat];
+        ListNat;
+      }
+      Terms {
+        Zero . Digit ::= "0";
+        One . Digit ::= "1";
+        Two . Digit ::= "2";
+        Three . Digit ::= "3";
+        Four  . Digit ::= "4";
+        Five  . Digit ::= "5";
+        Six   . Digit ::= "6";
+        Seven . Digit ::= "7";
+        Eight . Digit ::= "8";
+        Nine  . Digit ::= "9";
+        Nil . Nat ::= ;
+        Cons . Nat ::= Digit Nat;
+        []{Nat} . [Nat] ::= ;
+        (:){Nat} . [Nat] ::= Nat "," [Nat];
+        Brackets . ListNat ::= "[" [Nat] "]";
+        []{Digit} . [Digit] ::= ;
+        (:){Digit} . [Digit] ::= Digit ":" [Digit];
+      }
+      Equations {
+        ((:){Nat} x ((:){Nat} y ([]{Nat}))) == ((:){Nat} y ((:){Nat} x ([]{Nat})));
+      }
+  }
+}

--- a/GSLT/src/test/module/bad/RepeatLabel.module
+++ b/GSLT/src/test/module/bad/RepeatLabel.module
@@ -1,0 +1,11 @@
+Module RepeatLabel {
+  Theory R() {
+    Empty
+      Exports { T; }
+      Terms {
+        Foo . T ::= "Foo1";
+        Foo . T ::= "Foo2";
+      }
+  }
+  theory R()
+}

--- a/GSLT/src/test/module/bad/ReplacementShadows.module
+++ b/GSLT/src/test/module/bad/ReplacementShadows.module
@@ -1,0 +1,19 @@
+Module ReplacementShadows {
+  Theory One() {
+    Empty
+      Exports { T; }
+      Terms {
+        Foo . T ::= "Foo";
+        Bar . T ::= "Bar";
+      }
+  }
+  
+  Theory Two(one: One) {
+    one
+      Replacements {
+        [] Foo . T => Bar . T ::= "Oh-no!";
+      }
+  }
+  
+  theory Two(One())
+}

--- a/MeTTaIL/src/main/scala/io/f1r3fly/mettail/ASTHelpers.scala
+++ b/MeTTaIL/src/main/scala/io/f1r3fly/mettail/ASTHelpers.scala
@@ -30,7 +30,11 @@ object ASTHelpers {
     val javaList = listItem.asScala.map {
       case t: Terminal => t
       case nt: NTerminal => if (nt.cat_ == oldCat) new NTerminal(newCat) else nt
-      case ant: AbsNTerminal => if (ant.cat_ == oldCat) new AbsNTerminal(ant.ident_, newCat) else ant
+      case ant: AbsNTerminal => {
+        val antListItem = new ListItem()
+        antListItem.add(ant.item_)
+        new AbsNTerminal(ant.ident_, replaceCats(oldCat, newCat, antListItem).get(0))
+      }
       case bnt: BindNTerminal => if (bnt.cat_ == oldCat) new BindNTerminal(bnt.ident_, newCat) else bnt
     }.toSeq.asJava
     val newListItem = new ListItem()

--- a/MeTTaIL/src/main/scala/io/f1r3fly/mettail/LabelHelpers.scala
+++ b/MeTTaIL/src/main/scala/io/f1r3fly/mettail/LabelHelpers.scala
@@ -7,9 +7,9 @@ object LabelHelpers {
   private def labelToString(l: Label): String = l match {
     case id: Id => id.ident_
     case _: Wild => "_"
-    case _: ListE => "[]"
-    case _: ListCons => "(:)"
-    case _: ListOne => "(:[])"
+    case l: ListE => s"[]{${PrettyPrinter.print(l.cat_)}}"
+    case l: ListCons => s"(:){${PrettyPrinter.print(l.cat_)}}"
+    case l: ListOne => s"(:[]){${PrettyPrinter.print(l.cat_)}}"
   }
 
   private def labelsInAST(ast: AST): Set[String] = ast match {

--- a/MeTTaIL/src/test/scala/io/f1r3fly/mettail/InstInterpreterSpec.scala
+++ b/MeTTaIL/src/test/scala/io/f1r3fly/mettail/InstInterpreterSpec.scala
@@ -14,8 +14,7 @@ class InstInterpreterSpec extends AnyFlatSpec with Matchers {
     val entryPath   = moduleFile.getCanonicalPath
     val processor   = ModuleProcessor.default
     // Parse all imports and dependencies…
-    val resolvedMap = processor.resolveModules(entryPath)  
-                              // resolveModules: recursively parse modules and imports :contentReference[oaicite:0]{index=0}&#8203;:contentReference[oaicite:1]{index=1}
+    val resolvedMap = processor.resolveModules(entryPath)
     
     // Extract the single top‑level TheoryInst (the “main” inst) from the module
     val mainMod = resolvedMap(entryPath).asInstanceOf[ModuleImpl]

--- a/MeTTaIL/src/test/scala/io/f1r3fly/mettail/LabelHelpersSpec.scala
+++ b/MeTTaIL/src/test/scala/io/f1r3fly/mettail/LabelHelpersSpec.scala
@@ -11,34 +11,35 @@ class LabelHelpersSpec extends AnyFlatSpec with Matchers {
   "labelsInEquation" should "extract labels from an EquationImpl" in {
     val emptyListAST = new ListAST()
     val ast1 = new ASTSExp(new Id("foo"), emptyListAST)
-    val ast2 = new ASTSExp(new ListCons(), emptyListAST)
+    val ast2 = new ASTSExp(new ListCons(new IdCat("qux")), emptyListAST)
     val eqImpl = new EquationImpl(ast1, ast2)
 
     val labels = LabelHelpers.labelsInEquation(eqImpl)
-    labels should contain allOf ("foo", "(:)")
+    labels should contain allOf ("foo", "(:){qux}")
     labels.size shouldEqual 2
   }
 
   it should "delegate through EquationFresh" in {
     val emptyListAST = new ListAST()
     val ast1 = new ASTSExp(new Id("bar"), emptyListAST)
-    val ast2 = new ASTSExp(new ListE(), emptyListAST)
+    val ast2 = new ASTSExp(new ListE(new IdCat("qux")), emptyListAST)
     val eqImpl = new EquationImpl(ast1, ast2)
     val eqFresh = new EquationFresh("x", "y", eqImpl)
 
     val labels = LabelHelpers.labelsInEquation(eqFresh)
-    labels should contain allOf ("bar", "[]")
+    println(labels)
+    labels should contain allOf ("bar", "[]{qux}")
     labels.size shouldEqual 2
   }
 
   "labelsInRewrite" should "extract labels from a RewriteBase" in {
     val emptyListAST = new ListAST()
     val ast1 = new ASTSExp(new Id("baz"), emptyListAST)
-    val ast2 = new ASTSExp(new ListOne(), emptyListAST)
+    val ast2 = new ASTSExp(new ListOne(new IdCat("qux")), emptyListAST)
     val rwBase = new RewriteBase(ast1, ast2)
 
     val labels = LabelHelpers.labelsInRewrite(rwBase)
-    labels should contain allOf ("baz", "(:[])")
+    labels should contain allOf ("baz", "(:[]){qux}")
     labels.size shouldEqual 2
   }
 

--- a/hypercube.md
+++ b/hypercube.md
@@ -197,9 +197,10 @@ as "for each way that A₁ relates to B₁ in the context Γ, ..., and Aₙ rela
     //   (T1 -> T2)
     // is used as a category, so we generate 
     //   AppT1T2 . T2 ::= "α" "{" (T1 -> T2) "," T1 "}" ;
-    //   IdentT1T2 . (T1 -> T2) ::= Ident ;
+    //   IdentT1T2 . (T1 -> T2) ::= Ident ; 
     //   LamT1T2 . (T1 -> T2) ::= "λ" "{" Ident "," T2 "}" ;
     //   IdentT1 . T1 ::= Ident ;
+    // The IdentTX productions are the same as the one for Bind.
 
     // foo(bar)
     // ⇓ η
@@ -216,6 +217,9 @@ as "for each way that A₁ relates to B₁ in the context Γ, ..., and Aₙ rela
     
     // bee(λx.quux)
     bee λ{x, quux}
+    
+    // bee(λx.bar(λy.quux))
+    bee λ{x, bar y quux}
 
 - Start
 

--- a/hypercube.md
+++ b/hypercube.md
@@ -1,0 +1,635 @@
+Given an interactive finitely-presented GSLT T, produce new typed GSLT.
+
+Fn sym arrows o: X1 x ... x Xn -> Y are sugar for Γ ⊢ t1: X1 ... Γ ⊢ tn: Xn ⊨ Γ ⊢ o(t1, ..., tn): Y.
+Rewrite squiggly arrows ρ: os(t1, ..., tn) ~> ot(t1, ..., tn) are sugar for 
+    Γ ⊢ t1: X1 ... Γ ⊢ tn: Xn ⊨ Γ ⊢ s(ρ(t1, ..., tn)) = os(t1, ..., tn)
+    Γ ⊢ t1: X1 ... Γ ⊢ tn: Xn ⊨ Γ ⊢ t(ρ(t1, ..., tn)) = ot(t1, ..., tn)
+Equations os(t1, ..., tn) = ot(t1, ..., tn) are sugar for 
+    Γ ⊢ t1: X1 ... Γ ⊢ tn: Xn ⊨ Γ ⊢ os(t1, ..., tn) = ot(t1, ..., tn)
+
+- E.g. RHO calculus
+
+    shapes
+      // Automatically have R, V, s,t: R -> V.
+      P // First shape gets set equal to V as equation of identity morphisms.
+      N
+
+    fn syms
+      0: 1 -> P
+      |: P x P -> P
+      !: N x P -> P
+      ?: N x (N -> P) -> P
+      *: N -> P
+      @: P -> N
+
+    eqns
+      // V = P from above
+      comm. mon. eqns
+      @*n = n
+
+    rewrites
+      comm: N x (N -> P) x P -> R
+      comm: x?Q | x!R ~> ev(Q, @R)
+
+      par1: R x P -> R
+      par1: s(r) | p ~> t(r) | p
+
+      par2: R x R -> R
+      par2: s(r1) | s(r2) ~> t(r1) | t(r2)
+
+      run: P -> P
+      run: *@P ~> P
+
+- E.g. λ-calculus
+
+    shapes
+      // Automatically have R, V, s,t: R -> V.
+      P // First shape gets set equal to V as equation of identity morphisms.
+
+    fn syms
+      App: P x P -> P
+      Lam: (P -> P) -> P
+
+    eqns
+      // V = P from above
+
+    rewrites
+      beta: (P -> P) x P -> R
+      beta: App(Lam(K), Q) ~> ev(K, Q)
+
+      head: R x P -> R
+      head: App(s(E), Q) ~> App(t(E), Q)
+
+- E.g. SKI
+
+    shapes
+      // Automatically have R, V, s,t: R -> V.
+      P // First shape gets set equal to V as equation of identity morphisms.
+
+    fn syms
+      App: P x P -> P
+      S, K, I: 1 -> P
+      S1: P -> P
+      S2: P x P -> P
+      K1: P -> P
+
+    eqns
+      // V = P from above
+
+    rewrites
+      σ1: P -> R
+      σ1: App(S, x) ~> S1(x)
+
+      σ2: P x P -> R
+      σ2: App(S1(x) y) ~> S2(x, y)
+
+      σ3: P x P x P -> R
+      σ3: App(S2(x, y) z) ~> ((x z) (y z))
+
+      κ1: P -> R
+      κ1: App(K, x) ~> K1(x)
+
+      κ2: P x P -> R
+      κ2: App(K1(x), y) ~> x
+
+      ι1: P -> R
+      ι1: App(I, x) ~> x
+
+      head: R x P -> R
+      head: App(s(E), Q) ~> App(t(E), Q)
+
+- E.g. Ambient
+
+    shapes
+      // Automatically have R, V, s,t: R -> V.
+      P // First shape gets set equal to V as equation of identity morphisms.
+      N
+      M
+
+    fn syms
+      ν: (N -> P) -> P
+      0: 1 -> P
+      |: P x P -> P
+      !: P -> P
+      []: N x P -> P
+      .: M x P -> P
+      in, out, open: N -> M
+
+    eqns
+      comm. mon.
+      νx.νy.P = νy.νx.P
+      νx.νx.P = νx.P
+
+      Γ, x: N ⊢ Q1: P    Γ ⊢ Q2: P    ⊨    Γ ⊢ (νx.Q1) | Q2 = νx.(Q1 | Q2)
+
+    rewrites
+      expand: P -> R
+      expand: !Q ~> Q | !Q
+
+      ambient: N x R -> R
+      ambient: n[s(E)] ~> n[t(E)]
+
+      in: N x N x P x P x P -> R
+      in: n[in m.Q | R] | m[S] ~> m[n[Q | R] | S]
+
+      out: N x N x P x P x P -> R
+      out: m[n[out m:Q | R] | S] ~> n[Q | R] | m[S]
+
+      open: N x P x P -> R
+      open: open m.P | m[Q] ~> P | Q
+
+  - E.g. Rule 110?
+
+We'll consider the free theory on empty sets.  Since it's free, we get an algebra for building up terms and a coalgebra for taking them apart.  That lets us do destructuring assignment in the premises of an inference rule.
+
+We'll add term constructors and a typing endospan : on terms in a typing context.
+
+Judgments are of the form A: B where A and B are both terms (which may include free variables) of the same shape.  We write s^T to indicate that there are up to two rules, depending on where you are in the hypercube: one for type^T, one for kind^T (see Axiom below for those terms).  We can read "A: B" as "a way that A relates to B", since a span allows A to be related to B in multiple ways.
+
+Entailments involve a typing context (a list of variable typing judgments) on the left of a turnstile and a single term judgment on the right.  All the free variables on the right must appear on the left.  We read `Γ ⊢ A: B` as "a way that A relates to B in the context Γ".  More specifically, we read `x₁: X₁, ..., xₙ: Xₙ ⊢ A: B` as "for each way that x₁ relates to X₁, ..., and xₙ relates to Xₙ, a way that A relates to B".
+
+Inference rules have a list of entailments on top and an entailment on the bottom.  All the free metavariables on the bottom must appear on the top with the same variance.  We read
+
+  Γ ⊢ A₁: B₁    ⋯    Γ ⊢ Aₙ: Bₙ
+  —————————————————————————————
+  Γ ⊢ A: B
+
+as "for each way that A₁ relates to B₁ in the context Γ, ..., and Aₙ relates to Bₙ in the context Γ, a way that A relates to B in the context Γ".
+
+- Axiom
+
+    Add term constructors `*^T, □^T: 1 -> T` for each shape T in the theory.
+
+      Forall T . Type . T ::= "type" "^" ToString(T) ;
+      Forall T . Kind . T ::= "kind" "^" ToString(T) ;
+
+    Similar to how we turn binders into idents, maybe we add monomorphic versions of these rules to every category in the grammar?
+
+    BNFC has
+
+      Rule             . Def  ::= Label "." Cat "::=" [Item] ;
+      Terminal         . Item ::= String ;
+      NTerminal        . Item ::= Cat ;
+
+    so BNFC can do term constructors with products as inputs
+
+      Label: C1 x ... x Cn -> C,
+
+    while MeTTa IL also currently has
+
+      AbsNTerminal     . Item ::= "(" Ident ")" Cat;
+      BindNTerminal    . Item ::= "(" "Bind" Ident Cat ")" ;
+
+    so can do term constructors with internal homs as inputs, too, e.g.
+
+      Label: C1 x (C2 -> C3) x ((C4 -> C5) -> C6) -> C.
+
+    In both, the output category must be a generating category.  We'd like to add ArrowCat
+
+      ArrowCat . Cat ::= "(" Cat "->" Cat ")" ;
+
+    to support things like 
+
+      Type . (T1 -> T2) ::= "type" "^" ToString(T1 -> T2).
+
+    Things of this shape are term contexts.  The Pi constructor (see below) can be either a type or kind of that shape:
+
+      Γ ⊢ A: s₁^T    Γ, x: A ⊢ B: s₂^{T'}
+      ———————————————————————————————————.
+      Γ ⊢ ∏(T, T', A, λx.B): s₂^{T -> T'}
+    
+    From
+    
+      Foo . (T -> T') ::= "foo" ;
+    
+    we can derive something like
+    
+      UncurryFoo . T' ::= "foo" T ;
+      
+    In the case of ∏, we provide an A (a refinement of T) and get a B (a refinement of T').
+    
+    What about
+
+      Bar . ((T1 -> T2) -> T3) ::= "bar" ; ?
+
+    How do we provide a term context as input?  The rule itself?
+    
+      UncurryBar . T3 ::= "bar" Label . "(" ToString(T1) "->" ToString(T2) ")" "::=" [Item] ; ?
+    
+    
+    
+- Start
+
+    Γ ⊢ A: s
+    ——————————————
+    Γ, x: A ⊢ x: A
+
+- Weakening
+
+    Γ ⊢ A: B    Γ ⊢ C: s
+    ————————————————————
+    Γ, x: C ⊢ A: B
+
+- Dependent product, abstraction, application, beta equivalence as part of lambda theory
+
+    Add a term constructor `∏: T x (T -> T') -> T'` for each pair of shapes T, T' in the theory.
+    We write `∏(A, λx.B)` as `∏_{x: A}.B`.  (Do we need to track T, T' like we do on * & □?)
+
+    Γ ⊢ A: s₁^T    Γ, x: A ⊢ B: s₂^{T'}
+    ———————————————————————————————————
+    Γ ⊢ ∏_{x: A}.B: s₂^{T -> T'}
+    Γ ⊢ ∏(A, λx.B): s₂^{T -> T'}
+
+    Γ ⊢ A: s₁^T    Γ, x: A ⊢ B: s₂^{T'}    Γ, x: A ⊢ C: B
+    —————————————————————————————————————————————————————
+    Γ ⊢ λx.C: ∏_{x: A}.B
+    Γ ⊢ λx.C: ∏(A, λx.B)
+
+    Γ ⊢ C: ∏(A, λx.B)    Γ ⊢ D: A
+    Γ ⊢ C: ∏_{x: A}.B    Γ ⊢ D: A
+    —————————————————————————————
+    Γ ⊢ (C D): B[D / x]
+    Γ ⊢ (C D): (λx.B D)
+
+    Beta rules from lambda cube article...
+
+- For each term constructor, a pair of functions (one for structural type, one for term) and inference rules for principal structural types.
+
+  - E.g. RHO calc
+
+      ———————————
+      ⊢ 00^s: s^P
+
+      ———————————
+      ⊢ 0^s: 00^s
+
+
+
+      ————————————————————————————————
+      ⊢ ||: ∏_{A: s^P}.∏_{B: s^P}.s^P 
+
+      Γ ⊢ A: s^P
+      —————————————————
+      Γ ⊢ ||(A, 00^s) = A
+
+      Γ ⊢ A: s^P  Γ ⊢ B: s^P
+      ———————————————————————
+      Γ ⊢ ||(A, B) = ||(B, A)
+
+      Γ ⊢ A: s^P  Γ ⊢ B: s^P  Γ ⊢ C: s^P
+      —————————————————————————————————————
+      Γ ⊢ ||(||(A, B), C) = ||(A, ||(B, C))
+
+
+
+      ———————————————————————————————————————————————————————
+      ⊢ |: ∏_{A: s^P}.∏_{B: s^P}.∏_{C: A}.∏_{D: B}.||(A, B) 
+
+      Γ ⊢ A: s^P  Γ ⊢ C: A
+      ——————————————————————————
+      Γ ⊢ |(A, 00^s, C, 0^s) = C
+
+      Γ ⊢ A: s^P  Γ ⊢ B: s^P  Γ ⊢ C: A  Γ ⊢ D: B
+      ——————————————————————————————————————————
+      Γ ⊢ |(A, B, C, D) = |(B, A, D, C)
+
+      Γ ⊢ A: s^P  Γ ⊢ B: s^P  Γ ⊢ C: s^P  Γ ⊢ D: A  Γ ⊢ E: B  Γ ⊢ F: C
+      ———————————————————————————————————————————————————————————————————————
+      Γ ⊢ |(||(A, B), C, |(A, B, D, E), F) = |(A, ||(B, C), D, |(B, C, E, F))
+
+
+
+      ————————————————————————————————————————————
+      ⊢ !!: ∏_{A: s₁^N}.∏_{B: s₂^P}.∏_{x: A}.s₁^P
+
+      ———————————————————————————————————————————————————————————
+      ⊢ !: ∏_{A: s₁^N}.∏_{B: s₂^P}.∏_{x: A}.∏_{Q: B}.!!(A, B, x)
+
+
+      // Exponential, so need s₂ & s₃ for hypercube
+      Γ ⊢ A: s₁^N  Γ ⊢ B: s₂^N  Γ, y: B ⊢ C: s₃^P  Γ ⊢ x: A
+      —————————————————————————————————————————————————————
+      Γ ⊢ forfor(A, ∏_{y: B}.C, x): s₃^P <--- how is this forced?
+
+      Γ ⊢ A: s₁^N  Γ ⊢ B: s₂^N  Γ, y: B ⊢ C: s₃^P  Γ ⊢ x: A  Γ, y: B ⊢ D: C
+      ——————————————————————————————————————————————————————————————————————
+      Γ ⊢ for(A, ∏_{y: B}.C, x, λy: B. D): forfor(A, ∏_{y: B}.C, x)
+
+
+
+      —————————————————————
+      ⊢ @@: ∏_{A: s^P}.s^N
+
+      ———————————————————————————————
+      ⊢ @: ∏_{A: s^P}.∏_{B: A}.@@(A)
+
+      —————————————————————
+      ⊢ **: ∏_{A: s^N}.s^P
+
+      ———————————————————————————————
+      ⊢ *: ∏_{A: s^N}.∏_{x: A}.**(A)
+
+      Γ ⊢ A: s^P
+      —————————————————
+      Γ ⊢ **(@@(A)) = A
+
+      Γ ⊢ A: s^N
+      —————————————————
+      Γ ⊢ @@(**(N)) = N
+
+      Γ ⊢ A: s^P  Γ ⊢ B: A
+      —————————————————————————
+      Γ ⊢ *(@@(A), @(A, B)) = B
+
+      Γ ⊢ A: s^N  Γ ⊢ B: A
+      —————————————————————————
+      Γ ⊢ @(**(A), *(A, B)) = B
+
+
+      // Rewrites
+
+      —————————————————————————————————
+      ⊢ srcsrc, tgttgt: ∏_{A: s^R}.s^P
+
+      —————————————————————————————————————————————————
+      ⊢ src, tgt: ∏_{A: s^R}.∏_{r: A}.srcsrc/tgttgt(A)
+
+      // Non-dependent
+
+      Γ ⊢ A: s₁^N  Γ ⊢ B: s₂^P  Γ ⊢ C: s₁^P  Γ ⊢ x: A
+      ——————————————————————————————————————————————— y # C
+      Γ ⊢ commcomm(A, ∏_{y:@@(B)}.C, x): s₁^R
+
+      Γ ⊢ A: s₁^N  Γ ⊢ B: s₂^P  Γ ⊢ C: s₁^P  Γ ⊢ x: A  Γ, y: @@(B) ⊢ L: C  Γ ⊢ Q: B
+      ————————————————————————————————————————————————————————————————————————————— y # C
+      ⊢ comm(A, ∏_{y:@@(B)}.C, x, λy:@@(B).L, Q): commcomm(A, ∏_{y:@@(B)}.C, x)
+
+      // Dependent
+
+      Γ ⊢ A: s₁^N  Γ ⊢ B: s₂^P  Γ, y: @@(B) ⊢ C: s₁^P  Γ ⊢ x: A
+      —————————————————————————————————————————————————————————
+      Γ ⊢ commcomm(A, ∏_{y:@@(B)}.C, x): s₁^R
+
+      Γ ⊢ A: s₁^N  Γ ⊢ B: s₂^P  Γ, y: @@(B)⊢ C: s₁^P  Γ ⊢ x: A  Γ, y: @@(B) ⊢ L: C  Γ ⊢ Q: B
+      ——————————————————————————————————————————————————————————————————————————————————————
+      ⊢ comm(A, ∏_{y:@@(B)}.C, x, λy:@@(B).L, Q): commcomm(A, ∏_{y:@@(B)}.C, x)
+
+
+      ——————————————————————————————————————
+      ⊢ par1par1: ∏_{A: s^R}.∏_{B: s^P}.s^R
+
+      ————————————————————————————————————————————————————————————————
+      ⊢ par1: ∏_{A: s^R}.∏_{B: s^P}.∏_{r: A}.∏_{Q: B}.par1par1(A, B)
+
+      ——————————————————————————————————————
+      ⊢ par2par2: ∏_{A: s^R}.∏_{B: s^R}.s^R
+
+      ————————————————————————————————————————————————————————————————
+      ⊢ par2: ∏_{A: s^R}.∏_{B: s^R}.∏_{r1: A}.∏_{r2: B}.par2par2(A, B)
+
+
+
+      ////////////// Non-dependent continuation type //////////
+
+      Γ ⊢ A: s₁^N  Γ ⊢ B: s₂^P  Γ ⊢ C: s₁^P  Γ ⊢ x: A
+      ———————————————————————————————————————————————— y # C
+      Γ ⊢ srcsrc(commcomm(A, ∏_{y:@@(B)}.C, x))
+      .   ==
+      .   ||(!!(A, B, x), forfor(A, ∏_{y:@@(B)}.C, x))
+
+      Γ ⊢ A: s₁^N  Γ ⊢ B: s₂^P  Γ ⊢ C: s₁^P  Γ ⊢ x: A  Γ, y:@@(B) ⊢ L: C  Γ ⊢ Q: B
+      ——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————— y # C
+      Γ ⊢ src(commcomm(A, ∏_{y:@@(B)}.C, x), comm(A, ∏_{y:@@(B)}.C, x, λy:@@(B).L, Q)): srcsrc(commcomm(A, ∏_{y:@@(B)}.C, x))
+      .   ==
+      .   |(!!(A, B, x), forfor(A, ∏_{y:@@(B)}.C, x), !(A, B, x, Q), for(A, ∏_{y:B}.C, x, λy:@@(B).L)): ||(!!(A, B, x), forfor(A, ∏_{y:@@(B)}.C, x))
+
+      Γ ⊢ A: s₁^N  Γ ⊢ B: s₂^P  Γ ⊢ C: s₁^P  Γ ⊢ x: A
+      ———————————————————————————————————————————————— y # C
+      Γ ⊢ tgttgt(commcomm(A, ∏_{y:@@(B)}.C, x))
+      .   ==
+      .   C
+
+      Γ ⊢ A: s₁^N  Γ ⊢ B: s₂^P  Γ ⊢ C: s₁^P  Γ ⊢ x: A  Γ, y:@@(B) ⊢ L: C  Γ ⊢ Q: B
+      ———————————————————————————————————————————————————————————————————————————————————————————————————————————————————————— y # C
+      Γ ⊢ tgt(commcomm(A, ∏_{y:@@(B)}.C, x), comm(A, ∏_{y:@@(B)}.C, x, λy:@@(B).L, Q)): tgttgt(commcomm(A, ∏_{y:@@(B)}.C, x))
+      .   ==
+      .   ((λy:@@(B).L) @(B, Q)): C
+
+
+      ////////////// Dependent continuation type: no type equations //////////
+
+      Γ ⊢ A: s₁^N  Γ ⊢ B: s₂^P  Γ, y: @@(B) ⊢ C: s₁^P  Γ ⊢ x: A  Γ, y: @@(B) ⊢ L: C  Γ ⊢ Q: B
+      ———————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      Γ ⊢ src(commcomm(A, ∏_{y:@@(B)}.C, x), comm(A, ∏_{y:@@(B)}.C, x, λy:@@(B).L, Q)): srcsrc(commcomm(A, ∏_{y:@@(B)}.C, x))
+      .   ==
+      .   |(!!(A, B, x), forfor(A, ∏_{y:@@(B)}.C, x), !(A, B, x, Q), for(A, ∏_{y:B}.C, x, λy:@@(B).L)): ||(!!(A, B, x), forfor(A, ∏_{y:@@(B)}.C, x))
+
+      Γ ⊢ A: s₁^N  Γ ⊢ B: s₂^P  Γ, y: @@(B) ⊢ C: s₁^P  Γ ⊢ x: A  Γ, y:@@(B) ⊢ L: C  Γ ⊢ Q: B
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      Γ ⊢ tgt(commcomm(A, ∏_{y:@@(B)}.C, x), comm(A, ∏_{y:@@(B)}.C, x, λy:@@(B).L, Q)): tgttgt(commcomm(A, ∏_{y:@@(B)}.C, x))
+      .   ==
+      .   ((λy:@@(B).L) @(B, Q)): (λy: @@(B).C @(B, Q))
+
+
+      ////////////// Context rules //////////
+
+      Γ ⊢ A: s^R  Γ ⊢ B: s^P
+      ——————————————————————————
+      Γ ⊢ srcsrc(par1par1(A, B))
+      .   ==
+      .   ||(srcsrc(A), B)
+
+      Γ ⊢ A: s^R  Γ ⊢ B: s^P  Γ ⊢ C: A  Γ ⊢ D: B
+      —————————————————————————————————————————————————————————————————
+      Γ ⊢ src(par1par1(A, B), par1(A, B, C, D)): srcsrc(par1par1(A, B))
+      .   ==
+      .   |(srcsrc(A), B, src(A, C), D): ||(srcsrc(A), B)
+
+      Γ ⊢ A: s^R  Γ ⊢ B: s^P
+      ——————————————————————————
+      Γ ⊢ tgttgt(par1par1(A, B))
+      .   ==
+      .   ||(tgttgt(A), B)
+
+      Γ ⊢ A: s^R  Γ ⊢ B: s^P  Γ ⊢ C: A  Γ ⊢ D: B
+      —————————————————————————————————————————————————————————————————
+      Γ ⊢ tgt(par1par1(A, B), par1(A, B, C, D)): tgttgt(par1par1(A, B))
+      .   ==
+      .   |(tgttgt(A), B, tgt(A, C), D): ||(tgttgt(A), B)
+
+      // Reduction context distributes over modality
+
+      Q:A ~> Q':A'
+
+      Γ ⊢ A': s^P  Γ ⊢ Q: ◊A'  Γ, Y: s^P, y: Y ⊢ B: s^P     // A' and Y are the same sort because Q:◊A' replaces y:Y
+      ————————————————————————————————————————————————— K[Y, y]: B
+      Γ ⊢ K[◊A'/Y][Q/y]: B[◊A' / Y][Q / y]  // have
+      Γ ⊢ K[◊A'/Y][Q/y]: ◊B[A' / Y][Q' / y] // want
+
+
+      // Non-dependent B
+      Γ ⊢ A': s^P  Γ ⊢ Q: ◊A'  Γ, Y: s^P ⊢ B: s^P
+      ——————————————————————————————————————————— K[Y]: B, y # B  Can do polymorphic, type operator, non-dependent
+      Γ ⊢ K[◊A'/Y][Q/y]: B[◊A' / Y]
+      Γ ⊢ K[◊A'/Y][Q/y]: ◊B[A' / Y]
+
+      // Dependent B requires witness, so ◊ has to track the witness
+      Γ ⊢ A': s^P  Γ ⊢ Q: ◊(Q':A')  Γ, Y: s^P, y: Y ⊢ B: s^P     // A' and Y are the same sort because Q:◊A' replaces y:Y
+      —————————————————————————————————————————————————————— K[Y, y]: B
+      Γ ⊢ K[◊A'/Y][Q/y]: ◊(K[A'/Y][Q'/y]: B[A' / Y][Q' / y])
+
+
+
+
+- Conv-like rule
+
+    `◊: P -> P`
+
+    Γ ⊢ A: s
+    ——————————
+    Γ ⊢ ◊A: s
+
+    Γ ⊢ A: s    Γ ⊢ B: A    Γ ⊢ ρ: B ~> B'    Γ ⊢ B': A'
+    ————————————————————————————————————————————————————
+    Γ ⊢ B: ◊A'
+
+    `◊*: P -> P`
+
+    Γ ⊢ A: B
+    ———————————
+    Γ ⊢ A: ◊*B
+
+    Γ ⊢ A: ◊◊*B
+    —————————————
+    Γ ⊢ A: ◊*B
+
+    Γ ⊢ A: ◊*◊*B
+    —————————————
+    Γ ⊢ A: ◊*B
+
+- Modalities from all process-shaped subterms of LHS of base rewrites.  RHS gets turned into structural type.  Structural type has only type info in a slot when the type is a process; when it's not a process, the value is also part of the type (e.g. names in ambient/pi/RHO).  In this approach, the types aren't dependent.  For example, in the first SKI inference rule below, the term doesn't have access to z, so even though the result type does, the result type isn't actually dependent.  Also, we can't make S, x, or y depend on z because z would be free in the conclusion.
+
+  Also laws based on context rewrites.
+
+  Γ ⊢ <K(-)>B: □
+  ————————————————————
+  Γ ⊢ K(<K(-)>B) = ◊B
+
+  Γ ⊢ A: B
+  ——————————————
+  Γ ⊢ K(A): K(B)
+
+  - E.g. SKI `σ: App(App(App(S, x), y), z) ~> App(App(x, z), App(y, z)`
+                               `A   B   C`
+
+    Γ ⊢ A: s^P    Γ ⊢ x: A    Γ ⊢ B: s^P    Γ ⊢ y: B    Γ ⊢ C: s^P
+    ——————————————————————————————————————————————————————————————
+    Γ ⊢ App(App(S, x), y): <App(-, z: C)>App(App(A, C), App(B, C)) // Do we need a freshness assertion for z?
+
+    Γ ⊢ A: s^P    Γ ⊢ x: A    Γ ⊢ B: s^P    Γ ⊢ C: s^P
+    —————————————————————————————————————————————————————————————————
+    Γ ⊢ App(S, x): <App(App(-, y: B), z: C)>App(App(A, C), App(B, C))
+
+    Γ ⊢ A: s^P    Γ ⊢ B: s^P    Γ ⊢ C: s^P
+    ————————————————————————————————————————————————————————————————————
+    Γ ⊢ S: <App(App(App(-, x: A), y: B), z: C)>App(App(A, C), App(B, C))
+
+    Γ ⊢ A: s^P    Γ ⊢ x: A    Γ ⊢ B: s^P    Γ ⊢ C: s^P
+    —————————————————————————————————————————————————————————————————
+    Γ ⊢ x: <App(App(App(S, -), y: B), z: C)>App(App(A, C), App(B, C))
+
+    Γ ⊢ A: s^P    Γ ⊢ B: s^P    Γ ⊢ y: B    Γ ⊢ C: s^P
+    —————————————————————————————————————————————————————————————————
+    Γ ⊢ y: <App(App(App(S, x: A), -), z: C)>App(App(A, C), App(B, C))
+
+    Γ ⊢ A: s^P    Γ ⊢ B: s^P    Γ ⊢ C: s^P    Γ ⊢ z: C
+    —————————————————————————————————————————————————————————————————
+    Γ ⊢ z: <App(App(App(S, x: A), y: B), -)>App(App(A, C), App(B, C))
+
+    How do we get something like an arrow type from this?
+    S: (C=>B=>A) => (C=>B) => C => A
+
+    We need a context rule like
+
+    Γ, ρ: S ~> T ⊢ χ(ρ): K(S) ~> K'(T)    Γ ⊢ A: s₁    Γ ⊢ T: A
+    ———————————————————————————————————————————————————————————
+    Γ ⊢ K(S): ◊K'(A)
+
+    That is, because of ρ, S:◊A, so we could already derive K(S): K(◊A).  This is necessary to pull the diamond past the K.
+
+    Γ ⊢ <App(-, C)><App(-, B)>A: *^P    Γ ⊢ x: <App(-, C)><App(-, B)>A    Γ ⊢ <App(-, C)>B: *^P    Γ ⊢ y: <App(-, C)>B    Γ ⊢ C: *^P
+    ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+    Γ ⊢ App(App(S, x), y): <App(-, z: C)>App(App(<App(-, C)><App(-, B)>A, C), App(<App(-, C)>B, C))
+    ———————————————————————————————————————————————————————————————————————————————————————————————
+    Γ ⊢ App(App(S, x), y): <App(-, z: C)>App(◊<App(-, B)>A, ◊B)    Γ, ρ: S ~> T ⊢ head:App(S, Q) ~> App(T, Q)
+    ———————————————————————————————————————————————————————————————————————————————————————————————————————————— // what's this rule?  Need conversion rule that uses K.
+    Γ ⊢ App(App(S, x), y): <App(-, z: C)>◊◊A
+
+  - E.g. Ambient `in: n[ in m.Q | R ] | m[ S ] ~> m[ n[ Q | R ] | S ]`
+                     `A     B C   D     B  E`
+
+    Γ ⊢ A: s^N    Γ ⊢ m: A    Γ ⊢ B: s^N    Γ ⊢ n: B    Γ ⊢ C: s^P    Γ ⊢ Q: C    Γ ⊢ D: s^P    Γ ⊢ R: D    Γ ⊢ E: s^P
+    ——————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+    Γ ⊢ n[ in m.Q | R ]: < - | (m: A)[ S: E ]>(m: A)[(n: B)[ C | D ] | E ]
+
+    Γ ⊢ A: s^N    Γ ⊢ m: A    Γ ⊢ B: s^N    Γ ⊢ C: s^P    Γ ⊢ D: s^P    Γ ⊢ E: s^P    Γ ⊢ S: E
+    ——————————————————————————————————————————————————————————————————————————————————————————
+    Γ ⊢ m[ S ]: < (n: B)[ in (m: A).(Q: C) | (R: D) ] | ->(m: A)[(n: B)[ C | D ] | E ]
+
+    Γ ⊢ A: s^N    Γ ⊢ B: s^N    Γ ⊢ C: s^P    Γ ⊢ Q: C    Γ ⊢ D: s^P    Γ ⊢ E: s^P
+    ————————————————————————————————————————————————————————————————————————————————————
+    Γ ⊢ Q: <(n: B)[ in (m: A).- | (R: D) ] | (m: A)[ S: E ]>(m: A)[(n: B)[ C | D ] | E ]
+
+    Γ ⊢ A: s^N    Γ ⊢ B: s^N    Γ ⊢ C: s^P    Γ ⊢ D: s^P    Γ ⊢ R: D    Γ ⊢ E: s^P
+    ————————————————————————————————————————————————————————————————————————————————————
+    Γ ⊢ R: <(n: B)[ in (m: A).(Q: C) | - ] | (m: A)[ S: E ]>(m: A)[(n: B)[ C | D ] | E ]
+
+    Γ ⊢ A: s^N    Γ ⊢ B: s^N    Γ ⊢ C: s^P    Γ ⊢ D: s^P    Γ ⊢ E: s^P    Γ ⊢ S: E
+    ——————————————————————————————————————————————————————————————————————————————————————
+    Γ ⊢ S: <(n: B)[ in (m: A).(Q: C) | (R: D) ] | (m: A)[ - ]>(m: A)[(n: B)[ C | D ] | E ]
+
+  - What about ones where there's an exponential in the context?  E.g. Lambda `β: App(Lam(λx.C), D) ~> ev(λx.C, D)`.  Here we can put x into the context for B and C.  For example, suppose that A is bool, B is `[true, int] + [false, string]` (existential type).  Then ev(λx.B, D) will be either int or string.  But bool might be a subset of the values that we could put in the second slot to get one of those results, so the inference rule ends up weakening the type of D.  That seems OK.
+
+    Γ ⊢ A: s^P    Γ, x: A ⊢ B: s^P    Γ, x: A ⊢ C: B    Γ ⊢ D: A
+    ————————————————————————————————————————————————————————————
+    Γ ⊢ D: <App(Lam(λx.C: ∏x:A.B), -)>ev(λx.B, D)
+    Γ ⊢ D: <β>(A, λx.C, λx.B, D)
+
+- Conv can be used in any modality context:
+
+    Γ ⊢ A: ◊B    Γ ⊢ ρ: B ~> B'
+    —————————————————————————————
+    Γ ⊢ A: ◊◊B'
+
+    Γ ⊢ A: <B>C    Γ ⊢ ρ: C ~> C'
+    —————————————————————————————
+    Γ ⊢ A: <B>◊C'
+
+  - E.g. SKI
+
+    Γ ⊢ K: s^P    Γ ⊢ K: K    Γ ⊢ K: s^P    Γ ⊢ K: K    Γ ⊢ C: s^P
+    —————————————————————————————————————————————————————————————— modality
+    Γ ⊢ App(App(S, K), K): <App(-, z: C)>App(App(K, C), App(K, C))    Γ ⊢ κ(C, App(K, C): App(App(K, C), App(K, C)) ~> C
+    ———————————————————————————————————————————————————————————————————————————————————————————————————————————————————— conv
+    Γ ⊢ App(App(S, K), K): <App(-, z: C)>◊C
+
+- App-like rules for rewrites using ev
+
+  - E.g. RHO.
+
+      Γ ⊢ A: Pi(x, B, C, λQ.D)          Γ ⊢ x: B    Γ ⊢ S: C    Γ ⊢ λQ.D: ∏(C, λQ.s)
+      Γ ⊢ A: < - | x: B ! (Q: C) > D    Γ ⊢ x: B    Γ ⊢ S: C    Γ ⊢ λQ.D: ∏_{Q: C}.s
+      ——————————————————————————————————————————————————————————————————————————————
+      Γ ⊢ A | x!(S): ◊(D {S / Q})
+      Γ ⊢ A | x!(S): ◊ev(λQ.D, S)
+
+- Later: Cut-like rules for each rewrite target with a use of ev on an exponental object.  TODO: express extraction from wrapper in terms of coalgebraic structure of free GSLT.
+
+    for(chan, cont)
+    For(Chan, Pi)  Pi type holds lambda Pi(L) and in the consequent we could write ev(L, @E) instead of using sugar
+
+    Γ ⊢ for(x, K): ⟨|x:B!(Q:C)⟩D    Γ ⊢ E: C
+    ———————————————————————————————————————— cut-like = target of trace, compare app
+    Γ ⊢ ev(K, @E): ev(\Q.D, E)
+
+    From CILL: "Note that terms generated by cut-free proofs are in normal form; in particular, terms generated by the left rules have variables in the head position, so no redexes are created. Redexes only arise as a result of the substitutions performed by applications of the cut rule. Thus all computation is concentrated into the process of cut elimination."

--- a/test
+++ b/test
@@ -1,0 +1,1 @@
+cd MeTTaIL; sbt ";compile ;assembly ;test"; cd -


### PR DESCRIPTION
- Remove crufty comment
- Add categories to `List*` labels so they are unique. Also check uniqueness of labels when adding new terms
- Add checks for repeated labels, factor out common code
- Add test script
- Fix typo in BasePres, add more validation around replacements
- Move hypercube notes from rho4u
- Add stuff about arrow Cats
- Update abstraction to apply to an arbitrary item rather than just a category. Allows multiple variable abstractions like `(x)(y)body`.
