### PR TITLE
Corrects implementation of handleCtor()

### DIFF
--- a/MeTTaIL/src/main/scala/io/f1r3fly/mettail/InstInterpreterCases.scala
+++ b/MeTTaIL/src/main/scala/io/f1r3fly/mettail/InstInterpreterCases.scala
@@ -764,10 +764,7 @@ object InstInterpreterCases {
                   moduleProcessor: ModuleProcessor
                 ): BasePres = {
     val (modulePath, theoryDecl) =
-      moduleProcessor.resolveDottedPath(resolvedModules, currentModulePath, ctor.dottedpath_) match {
-        case Right(result) => result
-        case Left(msg)     => sys.error(s"Failed to resolve dotted path: $msg")
-      }
+      moduleProcessor.resolveDottedPath(resolvedModules, currentModulePath, ctor.dottedpath_).right.get
 
     val baseDecl = theoryDecl.asInstanceOf[BaseTheoryDecl]
     val actuals = ctor.listtheoryinst_.asScala.toList


### PR DESCRIPTION
@metaweta wrote:
-----------------------------------
moduleProcessor.resolveDottedPath(resolvedModules, currentModulePath, ctor.dottedpath_) match {
        case Right(result) => result
        case Left(msg)     => sys.error(s"Failed to resolve dotted path: $msg")

This logic should be moved to checkCtor. The handleCtor function should not fail.
-----------------------------------
This pull request corresponds to the above request.